### PR TITLE
Added the ability to set plink as ssh client when using native-git (with pageant it works for #24)

### DIFF
--- a/pass-winmenu/embedded/default-config.yaml
+++ b/pass-winmenu/embedded/default-config.yaml
@@ -25,6 +25,9 @@ sync-mode: builtin
 # Path to the Git executable that should be used. Only used when sync-mode
 # is set to 'native-git'.
 git-path: git
+# Path to the ssh client executable that should be used. Only used when sync-mode
+# is set to 'native-git'.
+ssh-path: 'C:\Program Files\PuTTY\plink.exe'
 
 # Amount of time (in seconds) your passwords should remain on the clipboard.
 clipboard-timeout: 30

--- a/pass-winmenu/include/packaged-config.yaml
+++ b/pass-winmenu/include/packaged-config.yaml
@@ -6,7 +6,7 @@
 # All values in this file are set to pass-winmenu's default settings,
 # so feel free to delete them from this file; they're only here
 # for your reference.
-password-store: '%userprofile%\.password-store'
+password-store: '%userprofile%\.pass'
 # A regex string against which all filenames in the password directory are
 # compared. All matching files are considered password files.
 password-file-match: '.*\.gpg$'
@@ -25,6 +25,9 @@ sync-mode: builtin
 # Path to the Git executable that should be used. Only used when sync-mode
 # is set to 'native-git'. 
 git-path: git
+# Path to the ssh client executable that should be used. Only used when sync-mode
+# is set to 'native-git'.
+ssh-path: 'C:\Program Files\PuTTY\plink.exe'
 
 # Amount of time (in seconds) your passwords should remain on the clipboard.
 clipboard-timeout: 30

--- a/pass-winmenu/src/Configuration/Config.cs
+++ b/pass-winmenu/src/Configuration/Config.cs
@@ -39,6 +39,7 @@ namespace PassWinmenu.Configuration
 
 
 		public bool UseGit { get; set; } = true;
+		public string SshPath { get; set; } = String.Empty;
 
 		[YamlIgnore]
 		public SyncMode SyncMode => (SyncMode)Enum.Parse(typeof(SyncMode), SyncModeString.ToPascalCase(), true);

--- a/pass-winmenu/src/ExternalPrograms/Git.cs
+++ b/pass-winmenu/src/ExternalPrograms/Git.cs
@@ -89,6 +89,10 @@ namespace PassWinmenu.ExternalPrograms
 				RedirectStandardOutput = true,
 				CreateNoWindow = true
 			};
+			if (!String.IsNullOrEmpty(Configuration.ConfigManager.Config.SshPath))
+			{
+				psi.EnvironmentVariables.Add("GIT_SSH", Configuration.ConfigManager.Config.SshPath);
+			}
 			Process gitProc;
 			try
 			{


### PR DESCRIPTION
Another option is to simply set core.sshCommand for the pass repo: `git config core.sshCommand '"C:/Program Files/PuTTY/plink.exe"'`