### PR TITLE
PGP exists with status 2, when editing a password file

### DIFF
--- a/pass-winmenu/src/ExternalPrograms/GPG.cs
+++ b/pass-winmenu/src/ExternalPrograms/GPG.cs
@@ -273,8 +273,12 @@ namespace PassWinmenu.ExternalPrograms
 		{
 			if (recipients == null) recipients = new string[0];
 			var recipientList = string.Join(" ", recipients.Select(r => $"--recipient \"{r}\""));
-
-			var result = CallGpg($"--output \"{outputFile}\" {recipientList} --encrypt", data);
+			var pgpArgs = $"--output \"{outputFile}\" {recipientList} --encrypt";
+			if (File.Exists(outputFile))
+			{
+				pgpArgs += " --yes";
+			}
+			var result = CallGpg(pgpArgs, data);
 			VerifyEncryption(result);
 		}
 


### PR DESCRIPTION
First for all, i have to say i like you project!
I am currently migrating from a keypass store (by hand, as i want so sort out some old passwords).

Suddenly i misstypes the username of one password-file and tried to edit it.
With your release version i was not able, so i grabbed the source and tried to investigate.

I got GnuPGP 2.2.10 installed (which was installed a time ago with Kleopatra).
When debugging the code i recognized, that PGP got an exist code 2.
After a short google session i found that a `--yes` is needed to override an existing output file.

Please find the linked patch, to add the argument, if the output file exists.

I am not sure if thats the right/best way to solve it, but for me it works.